### PR TITLE
Add functions to show systems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InfrastructureSystems = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
 PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # PowerSystemCaseBuilder.jl
+
+## Show all systems for all categories.
+
+```julia
+using PowerSystemCaseBuilder
+
+show_systems()
+```
+
+## Show all categories.
+
+```julia
+using PowerSystemCaseBuilder
+
+show_categories()
+```
+
+## Show all systems for one category.
+
+```julia
+using PowerSystemCaseBuilder
+
+show_systems(SIIPExampleSystems)
+```
+
+## Build a system
+
+```julia
+sys = build_system(SIIPExampleSystems, "5_bus_hydro_ed_sys")
+```

--- a/src/PowerSystemCaseBuilder.jl
+++ b/src/PowerSystemCaseBuilder.jl
@@ -14,6 +14,10 @@ export PSSETestSystems
 export MatPowerTestSystems
 
 export build_system
+export list_categories
+export show_categories
+export list_systems
+export show_systems
 
 export SYSTEM_CATELOG
 
@@ -23,6 +27,7 @@ import InfrastructureSystems: InfrastructureSystemsType
 import PowerSystems
 import DataStructures: SortedDict
 import DataFrames
+import PrettyTables
 
 #TimeStamp Management Imports
 import TimeSeries

--- a/src/system_catalog.jl
+++ b/src/system_catalog.jl
@@ -25,6 +25,13 @@ function get_system_descriptors(category::Type{<:SystemCategory}, catalog::Syste
     end
 end
 
+function list_categories()
+    catalog = SystemCatalog()
+    return list_categories(catalog)
+end
+
+list_categories(c::SystemCatalog) = sort!([x for x in (keys(c.data))], by = x -> string(x))
+
 function SystemCatalog(system_catalogue::Array{SystemDescriptor} = SYSTEM_CATELOG)
     data = Dict{DataType, Dict{String, SystemDescriptor}}()
     for descriptor in system_catalogue

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -18,14 +18,40 @@ function Base.show(io::IO, sys::SystemCatalog)
     show(df, allrows = true)
 end
 
-function list_systems(sys::SystemCatalog, category::Type{<:SystemCategory})
-    df = DataFrames.DataFrame(Name = [], Descriptor = [])
+function list_systems(sys::SystemCatalog, category::Type{<:SystemCategory}; kwargs...)
     descriptors = get_system_descriptors(category, sys)
-    for d in descriptors
-        push!(df, (get_name(d), get_description(d)))
+    sort!(descriptors, by = x -> x.name)
+    header = ["Name", "Descriptor"]
+    data = Array{Any, 2}(undef, length(descriptors), length(header))
+    for (i, d) in enumerate(descriptors)
+        data[i, 1] = get_name(d)
+        data[i, 2] = get_description(d)
     end
-    show(df, allrows = true, truncate = 92, rowlabel = :Name)
+
+    PrettyTables.pretty_table(stdout, data, header, alignment = :l; kwargs...)
 end
+
+show_categories() = println(join(string.(list_categories()), "\n"))
+
+function show_systems(; kwargs...)
+    catalog = SystemCatalog()
+    show_systems(catalog; kwargs...)
+end
+
+function show_systems(category::Type{<:SystemCategory}; kwargs...)
+    catalog = SystemCatalog()
+    show_systems(catalog, category; kwargs...)
+end
+
+function show_systems(catalog::SystemCatalog; kwargs...)
+    for category in list_categories(catalog)
+        println("\nCategory: $category\n")
+        list_systems(catalog, category)
+    end
+end
+
+show_systems(s::SystemCatalog, c::Type{<:SystemCategory}; kwargs...) =
+    list_systems(s, c; kwargs...)
 
 function print_stats(data::SystemDescriptor)
     df = DataFrames.DataFrame(Name = [], Value = [])


### PR DESCRIPTION
This makes it a bit easier to see what's available. Uses PrettyTables instead of DataFrames. Here are some examples:

```
julia> show_systems()

Category: MatPowerTestSystems

┌──────────────────────────────┬───────────────────────────────────┐
│ Name                         │ Descriptor                        │
├──────────────────────────────┼───────────────────────────────────┤
│ matpower_ACTIVSg10k_sys      │ ACTIVSg10k Test system            │
│ matpower_ACTIVSg2000_sys     │ MATPOWER ACTIVSg2000 Test system  │
│ matpower_RTS_GMLC_sys        │ Matpower RTS-GMLC Test system     │
│ matpower_case14_sys          │ Matpower Test system              │
│ matpower_case24_sys          │ Matpower Test system              │
│ matpower_case2_sys           │ Matpower Test system              │
│ matpower_case30_sys          │ Matpower Test system              │
│ matpower_case3_tnep_sys      │ Matpower Test system              │
│ matpower_case5_asym_sys      │ Matpower Test system              │
│ matpower_case5_dc_sys        │ Matpower Test system              │
│ matpower_case5_gap_sys       │ Matpower Test system              │
│ matpower_case5_pwlc_sys      │ Matpower Test system              │
│ matpower_case5_re_intid_sys  │ Matpower Test system              │
│ matpower_case5_re_sys        │ Matpower Test system              │
│ matpower_case5_re_uc_pwl_sys │ Matpower Test system              │
│ matpower_case5_re_uc_sys     │ Matpower Test system              │
│ matpower_case5_strg_sys      │ Matpower Test system              │
│ matpower_case5_sys           │ Matpower Test system              │
│ matpower_case5_th_intid_sys  │ Matpower Test system              │
│ matpower_case5_tnep_sys      │ Matpower Test system              │
│ matpower_case6_sys           │ Matpower Test system              │
│ matpower_case7_tplgy_sys     │ Matpower Test system              │
│ matpower_frankenstein_00_sys │ Matpower Frankenstein Test system │
└──────────────────────────────┴───────────────────────────────────┘

Category: PSITestSystems

┌─────────────────────────┬─────────────────────────────────────────────────────────────────────────────────┐
│ Name                    │ Descriptor                                                                      │
├─────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
│ c_duration_test         │ 1 Bus for duration testing                                                      │
│ c_linear_pwl_test       │ 1 Bus lineal PWL linear testing                                                 │
│ c_market_bid_cost       │ 1 bus system with MarketBidCost Model                                           │
│ c_ramp_test             │ 1-bus for ramp testing                                                          │
│ c_sos_pwl_test          │ 1 Bus lineal PWL sos testing                                                    │
│ c_sys14                 │ 14-bus system                                                                   │
│ c_sys14_dc              │ 14-bus system with DC line                                                      │
│ c_sys5                  │ 5-bus system                                                                    │
│ c_sys5_bat              │ 5-bus system with Storage Device                                                │
│ c_sys5_bat_ems          │ 5-bus system with Storage Device with EMS                                       │
│ c_sys5_dc               │ Systems with HVDC data in the branches                                          │
│ c_sys5_ed               │ 5-bus System for Economic Dispatch Simulations                                  │
│ c_sys5_hy               │ 5-bus system with HydroDispatch                                                 │
│ c_sys5_hy_ed            │ 5-bus system with Hydro-Power for Economic Dispatch Simulations                 │
│ c_sys5_hy_uc            │ 5-bus system with Hydro-Power for Unit Commitment Simulations                   │
│ c_sys5_hyd              │ 5-bus system with Hydro Energy Reservoir                                        │
│ c_sys5_il               │ System with Interruptible Load                                                  │
│ c_sys5_ml               │                                                                                 │
│ c_sys5_pglib            │ 5-bus with ThermalMultiStart                                                    │
│ c_sys5_pglib_sim        │ 5-bus with ThermalMultiStart for simulation                                     │
│ c_sys5_phes_ed          │ 5-bus system with Hydro Pumped Energy Storage for Economic Dispatch Simulations │
│ c_sys5_pwl_ed           │ 5-bus with pwl cost function                                                    │
│ c_sys5_pwl_ed_nonconvex │ 5-bus with SOS cost function for Economic Dispatch Simulations                  │
│ c_sys5_pwl_uc           │ 5-bus with SOS cost function for Unit Commitment Simulations                    │
│ c_sys5_re               │ 5-bus system with Renewable Energy                                              │
│ c_sys5_re_only          │ 5-bus system with only Renewable Energy                                         │
│ c_sys5_reg              │ 5-bus with regulation devices and AGC                                           │
│ c_sys5_uc               │ 5-bus system for Unit Commitment Simulations                                    │
│ test_RTS_GMLC_sys       │ RTS-GMLC test system                                                            │
└─────────────────────────┴─────────────────────────────────────────────────────────────────────────────────┘
```

```
julia> show_systems(SIIPExampleSystems)
┌────────────────────┬────────────────────────────────────┐
│ Name               │ Descriptor                         │
├────────────────────┼────────────────────────────────────┤
│ 5_bus_hydro_ed_sys │ 5-bus hydro economic dispatch data │
│ 5_bus_hydro_uc_sys │ 5-bus hydro unit commitment data   │
└────────────────────┴────────────────────────────────────┘
```